### PR TITLE
Extend user_context with additional data

### DIFF
--- a/cart_context.json
+++ b/cart_context.json
@@ -1,0 +1,42 @@
+{
+  "description": "Schema for storing cart context.",
+  "self": {
+    "vendor": "com.oda",
+    "name": "cart_context",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "num_products_in_cart": {
+      "description": "Current number of products in cart.",
+      "type": "integer",
+      "maximum": 9999999999,
+      "minimum": 0
+    },
+    "net_price_cart": {
+      "description": "The total net price of the cart.",
+      "type": "number"
+    },
+    "net_profit_cart": {
+      "description": "The total net profit of the cart.",
+      "type": "number"
+    },
+    "num_recipes_in_cart": {
+      "description": "Current number of recipes in the cart.",
+      "type": "integer",
+      "maximum": 9999999999,
+      "minimum": 0
+    },
+    "delivery_slot_id": {
+      "description": "The delivery slot currently selected",
+      "type": "integer"
+    },
+    "currency": {
+      "description": "The currency the user is browsing the site in.",
+      "type": "string",
+      "maxLength": 128
+    }
+  },
+  "additionalProperties": false
+}

--- a/user_context.json
+++ b/user_context.json
@@ -23,6 +23,11 @@
       "type": "string",
       "maxLength": 128
     },
+    "currency": {
+      "description": "The currency the user is browsing the site in.",
+      "type": "string",
+      "maxLength": 128
+    },
     "browser_cookie_id": {
       "description": "The value of the current browser_cookie_id.",
       "type": "string",
@@ -44,7 +49,7 @@
       },
       "maxItems": 9999999999
     },
-    "gross_price_cart": {
+    "net_price_cart": {
       "description": "The gross price of the cart.",
       "type": "number"
     },

--- a/user_context.json
+++ b/user_context.json
@@ -39,16 +39,6 @@
       "maximum": 9999999999,
       "minimum": 0
     },
-    "products_in_cart": {
-      "description": "The product id's in the cart.",
-      "type": "array",
-      "items": {
-        "description": "Product id",
-        "type": "string",
-        "maxLength": 128
-      },
-      "maxItems": 9999999999
-    },
     "net_price_cart": {
       "description": "The total net price of the cart.",
       "type": "number"
@@ -62,16 +52,6 @@
       "type": "integer",
       "maximum": 9999999999,
       "minimum": 0
-    },
-    "recipes_in_cart": {
-      "description": "The recipe id's in the cart.",
-      "type": "array",
-      "items": {
-        "description": "Recipe id",
-        "type": "string",
-        "maxLength": 128
-      },
-      "maxItems": 9999999999
     },
     "delivery_slot_id": {
       "description": "The delivery slot currently selected",

--- a/user_context.json
+++ b/user_context.json
@@ -32,30 +32,6 @@
       "description": "The value of the current browser_cookie_id.",
       "type": "string",
       "maxLength": 128
-    },
-    "num_products_in_cart": {
-      "description": "Current number of products in cart.",
-      "type": "integer",
-      "maximum": 9999999999,
-      "minimum": 0
-    },
-    "net_price_cart": {
-      "description": "The total net price of the cart.",
-      "type": "number"
-    },
-    "net_profit_cart": {
-      "description": "The total net profit of the cart.",
-      "type": "number"
-    },
-    "num_recipes_in_cart": {
-      "description": "Current number of recipes in the cart.",
-      "type": "integer",
-      "maximum": 9999999999,
-      "minimum": 0
-    },
-    "delivery_slot_id": {
-      "description": "The delivery slot currently selected",
-      "type": "integer"
     }
   },
   "additionalProperties": false

--- a/user_context.json
+++ b/user_context.json
@@ -50,7 +50,11 @@
       "maxItems": 9999999999
     },
     "net_price_cart": {
-      "description": "The gross price of the cart.",
+      "description": "The total net price of the cart.",
+      "type": "number"
+    },
+    "net_profit_cart": {
+      "description": "The total net profit of the cart.",
       "type": "number"
     },
     "num_recipes_in_cart": {

--- a/user_context.json
+++ b/user_context.json
@@ -4,7 +4,7 @@
     "vendor": "com.oda",
     "name": "user_context",
     "format": "jsonschema",
-    "version": "1-0-0"
+    "version": "1-0-1"
   },
   "type": "object",
   "properties": {
@@ -27,6 +27,36 @@
       "description": "The value of the current browser_cookie_id.",
       "type": "string",
       "maxLength": 128
+    },
+    "num_products_in_cart": {
+      "description": "Current number of products in cart.",
+      "type": "integer",
+      "maximum": 9999999999,
+      "minimum": 0
+    },
+    "products_in_cart": {
+      "description": "The product ids in the cart.",
+      "type": "array",
+      "items": {
+        "description": "Product id",
+        "type": "string",
+        "maxLength": 128
+      },
+      "maxItems": 9999999999
+    },
+    "gross_price_cart": {
+      "description": "The gross price of the cart.",
+      "type": "number"
+    },
+    "num_recipes_in_cart": {
+      "description": "Current number of recipes in the cart.",
+      "type": "integer",
+      "maximum": 9999999999,
+      "minimum": 0
+    },
+    "delivery_slot_selected": {
+      "description": "Have the user selected a delivery slot?",
+      "type": "boolean"
     }
   },
   "additionalProperties": false

--- a/user_context.json
+++ b/user_context.json
@@ -35,7 +35,7 @@
       "minimum": 0
     },
     "products_in_cart": {
-      "description": "The product ids in the cart.",
+      "description": "The product id's in the cart.",
       "type": "array",
       "items": {
         "description": "Product id",
@@ -54,9 +54,19 @@
       "maximum": 9999999999,
       "minimum": 0
     },
-    "delivery_slot_selected": {
-      "description": "Have the user selected a delivery slot?",
-      "type": "boolean"
+    "recipes_in_cart": {
+      "description": "The recipe id's in the cart.",
+      "type": "array",
+      "items": {
+        "description": "Recipe id",
+        "type": "string",
+        "maxLength": 128
+      },
+      "maxItems": 9999999999
+    },
+    "delivery_slot_id": {
+      "description": "The delivery slot currently selected",
+      "type": "integer"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
This context is added on most events (everything except page pings and perhaps page/screen views). Any other data you can think of we should add?