### PR TITLE
Add location detail to context

### DIFF
--- a/location_context.json
+++ b/location_context.json
@@ -4,7 +4,7 @@
     "vendor": "com.oda",
     "name": "location_context",
     "format": "jsonschema",
-    "version": "1-0-0"
+    "version": "1-1-0"
   },
   "type": "object",
   "properties": {
@@ -12,10 +12,13 @@
       "description": "Name of the location",
       "type": "string",
       "maxLength": 128
+    },
+    "location_detail_name": {
+      "description": "Name of the location detail",
+      "type": "string",
+      "maxLength": 128
     }
   },
   "additionalProperties": false,
-  "required": [
-    "location_name"
-  ]
+  "required": ["location_name"]
 }


### PR DESCRIPTION
Adds a detail location to describe a sub-location, like "Taco" for the page /dinners/taco