### PR TITLE
Add order context

### DIFF
--- a/order_context.json
+++ b/order_context.json
@@ -1,0 +1,66 @@
+{
+  "description": "Schema for order context.",
+  "self": {
+    "vendor": "com.oda",
+    "name": "order_context",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "order_id": {
+      "description": "The hashed order id.",
+      "type": "string",
+      "maxLength": 128
+    },
+    "delivery_slot_id": {
+      "description": "The delivery slot currently selected",
+      "type": "integer"
+    },
+    "net_price": {
+      "description": "The total net price of the order.",
+      "type": "number"
+    },
+    "num_products": {
+      "description": "Number of products. Sample products, coupons, discounts, fees are excluded.",
+      "type": "integer",
+      "maximum": 9999999999,
+      "minimum": 0
+    },
+    "num_recipes": {
+      "description": "Number of recipes in the order.",
+      "type": "integer",
+      "maximum": 9999999999,
+      "minimum": 0
+    },
+    "num_coupons": {
+      "description": "Number of coupons applied to the order.",
+      "type": "integer",
+      "maximum": 9999999999,
+      "minimum": 0
+    },
+    "payment_method": {
+      "description": "Name of the payment method last used on the order.",
+      "type": "string",
+      "maxLength": 128
+    },
+    "num_order_changes": {
+      "description": "Number of changes made on the order.",
+      "type": "integer",
+      "maximum": 9999999999,
+      "minimum": 0
+    },
+    "num_orders": {
+      "description": "Number of orders the user have.",
+      "type": "integer",
+      "maximum": 9999999999,
+      "minimum": 0
+    },
+    "currency": {
+      "description": "The currency the user is browsing the site in.",
+      "type": "string",
+      "maxLength": 128
+    }
+  },
+  "additionalProperties": false
+}

--- a/order_context.json
+++ b/order_context.json
@@ -21,6 +21,11 @@
       "description": "The total net price of the order.",
       "type": "number"
     },
+    "currency": {
+      "description": "The currency set on the order.",
+      "type": "string",
+      "maxLength": 128
+    },
     "num_products": {
       "description": "Number of products. Sample products, coupons, discounts, fees are excluded.",
       "type": "integer",
@@ -55,11 +60,6 @@
       "type": "integer",
       "maximum": 9999999999,
       "minimum": 0
-    },
-    "currency": {
-      "description": "The currency the user is browsing the site in.",
-      "type": "string",
-      "maxLength": 128
     }
   },
   "additionalProperties": false

--- a/order_context.json
+++ b/order_context.json
@@ -8,8 +8,8 @@
   },
   "type": "object",
   "properties": {
-    "order_id": {
-      "description": "The hashed order id.",
+    "order_number": {
+      "description": "The order number.",
       "type": "string",
       "maxLength": 256
     }

--- a/order_context.json
+++ b/order_context.json
@@ -17,6 +17,11 @@
       "description": "The delivery slot currently selected",
       "type": "integer"
     },
+    "delivery_date": {
+      "description": "The delivery date for the slot selected.",
+      "type": "string",
+      "maxLength": 12
+    },
     "net_price": {
       "description": "The total net price of the order.",
       "type": "number"

--- a/order_context.json
+++ b/order_context.json
@@ -32,6 +32,12 @@
       "maximum": 9999999999,
       "minimum": 0
     },
+    "num_categories": {
+      "description": "Number of categories in the order.",
+      "type": "integer",
+      "maximum": 9999999999,
+      "minimum": 0
+    },
     "num_recipes": {
       "description": "Number of recipes in the order.",
       "type": "integer",

--- a/order_context.json
+++ b/order_context.json
@@ -11,66 +11,7 @@
     "order_id": {
       "description": "The hashed order id.",
       "type": "string",
-      "maxLength": 128
-    },
-    "delivery_slot_id": {
-      "description": "The delivery slot currently selected",
-      "type": "integer"
-    },
-    "delivery_date": {
-      "description": "The delivery date for the slot selected.",
-      "type": "string",
-      "maxLength": 12
-    },
-    "net_price": {
-      "description": "The total net price of the order.",
-      "type": "number"
-    },
-    "currency": {
-      "description": "The currency set on the order.",
-      "type": "string",
-      "maxLength": 128
-    },
-    "num_products": {
-      "description": "Number of products. Sample products, coupons, discounts, fees are excluded.",
-      "type": "integer",
-      "maximum": 9999999999,
-      "minimum": 0
-    },
-    "num_categories": {
-      "description": "Number of categories in the order.",
-      "type": "integer",
-      "maximum": 9999999999,
-      "minimum": 0
-    },
-    "num_recipes": {
-      "description": "Number of recipes in the order.",
-      "type": "integer",
-      "maximum": 9999999999,
-      "minimum": 0
-    },
-    "num_coupons": {
-      "description": "Number of coupons applied to the order.",
-      "type": "integer",
-      "maximum": 9999999999,
-      "minimum": 0
-    },
-    "payment_method": {
-      "description": "Name of the payment method last used on the order.",
-      "type": "string",
-      "maxLength": 128
-    },
-    "num_order_changes": {
-      "description": "Number of changes made on the order.",
-      "type": "integer",
-      "maximum": 9999999999,
-      "minimum": 0
-    },
-    "num_orders": {
-      "description": "Number of orders the user have.",
-      "type": "integer",
-      "maximum": 9999999999,
-      "minimum": 0
+      "maxLength": 256
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
To be attached to all "order" events, such as "checkout_completed", "order_changed", "payment_failed", etc.

Note that all order data can be enriched in snowflake through the order_id, so we should not bloat this context completely. But having the most commonly used data quickly available would improve the end user experience for quick ad-hoc queries.