### PR TITLE
Add context schema for product impressions

### DIFF
--- a/product_impression_context.json
+++ b/product_impression_context.json
@@ -8,8 +8,8 @@
   },
   "type": "object",
   "properties": {
-    "request_url": {
-      "description": "The url of the request asking for products",
+    "location": {
+      "description": "Describes what kind of page location or context the product was returned for",
       "type": "string",
       "maxLength": 256
     },
@@ -17,11 +17,6 @@
       "description": "If pagination, this will describe the page",
       "maximum": 100,
       "minimum": 1
-    },
-    "location": {
-      "description": "Describes what kind of page location or context the product was returned for",
-      "type": "string",
-      "maxLength": 256
     },
     "response_type": {
       "type": "string",

--- a/product_impression_context.json
+++ b/product_impression_context.json
@@ -1,0 +1,45 @@
+{
+  "description": "Describing server-side stored product impressions, i.e. products that were returned from the backend (both api and web)",
+  "self": {
+    "vendor": "com.oda",
+    "name": "product_impression_context",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "request_url": {
+      "description": "The url of the request asking for products",
+      "type": "string",
+      "maxLength": 256
+    },
+    "pagination_page": {
+      "description": "If pagination, this will describe the page",
+      "maximum": 100,
+      "minimum": 1
+    },
+    "location": {
+      "description": "Describes what kind of page location or context the product was returned for",
+      "type": "string",
+      "maxLength": 256
+    },
+    "response_type": {
+      "type": "string",
+      "description": "Describes if the products are returned for a WEB or API request",
+      "enum": [
+        "API",
+        "WEB"
+      ]
+    },
+    "products": {
+      "description": "The product IDs for the returned products",
+      "type": "array",
+      "items": {
+        "description": "Product id",
+        "type": "integer"
+      }
+    }
+  },
+  "additionalProperties": false
+}
+

--- a/product_impression_context.json
+++ b/product_impression_context.json
@@ -8,25 +8,32 @@
   },
   "type": "object",
   "properties": {
-    "location": {
-      "description": "Describes what kind of page location or context the product was returned for",
+    "seen_at": {
+      "description": "Denoting where the customer have seen the products",
       "type": "string",
       "maxLength": 256
     },
-    "pagination_page": {
-      "description": "If pagination, this will describe the page",
-      "maximum": 100,
-      "minimum": 1
-    },
     "products": {
-      "description": "The product IDs for the returned products",
+      "description": "The product IDs in the impression",
       "type": "array",
       "items": {
         "description": "Product id",
         "type": "integer"
       }
+    },
+    "campaigns": {
+      "description": "The campaign IDs for the products in the impression",
+      "type": "array",
+      "items": {
+        "description": "Campaign id",
+        "type": "integer"
+      }
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "required": [
+    "products",
+    "seen_at"
+  ]
 }
 

--- a/product_impression_context.json
+++ b/product_impression_context.json
@@ -4,11 +4,11 @@
     "vendor": "com.oda",
     "name": "product_impression_context",
     "format": "jsonschema",
-    "version": "1-0-0"
+    "version": "1-0-1"
   },
   "type": "object",
   "properties": {
-    "seen_at": {
+    "impression_context": {
       "description": "Denoting where the customer have seen the products",
       "type": "string",
       "maxLength": 256
@@ -32,8 +32,8 @@
   },
   "additionalProperties": false,
   "required": [
-    "products",
-    "seen_at"
+    "impression_context",
+    "products"
   ]
 }
 

--- a/product_impression_context.json
+++ b/product_impression_context.json
@@ -18,7 +18,7 @@
       "maximum": 100,
       "minimum": 1
     },
-    "response_type": {
+    "request_type": {
       "type": "string",
       "description": "Describes if the products are returned for a WEB or API request",
       "enum": [

--- a/product_impression_context.json
+++ b/product_impression_context.json
@@ -18,14 +18,6 @@
       "maximum": 100,
       "minimum": 1
     },
-    "request_type": {
-      "type": "string",
-      "description": "Describes if the products are returned for a WEB or API request",
-      "enum": [
-        "API",
-        "WEB"
-      ]
-    },
     "products": {
       "description": "The product IDs for the returned products",
       "type": "array",


### PR DESCRIPTION
We also want to append campaign id for products if they are part of an ongoing campaign, but I see that arrays only support integers, and not objects. Any idea for how we can solve this? Do we need to store another separate event?